### PR TITLE
README: Correct broken links for tutorials 1-9

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ A series of Elementary Python tutorials.
 [Python Elementary Reference Docs](https://build.enlightenment.org/job/base_pyefl_build/lastSuccessfulBuild/artifact/build/sphinx/html/index.html)
 
 Tutorials:
-- 1.) [Hello Elementary](http://it.toolbox.com/blogs/enlightenment/pyefl-tutorial-1-hello-elementary-65743)
-- 2.) [Weight Hints](http://it.toolbox.com/blogs/enlightenment/pyefl-tutorial-2-weight-hints-65905)
-- 3.) [Align Hints](http://it.toolbox.com/blogs/enlightenment/pyefl-tutorial-3-align-hints-66348)
-- 4.) [Images / FileselectorButton](http://it.toolbox.com/blogs/enlightenment/pyefl-tutorial-4-displaying-images-66459)
-- 5.) [Naviframe](http://it.toolbox.com/blogs/enlightenment/pyefl-tutorial-5-naviframe-68138)
-- 6.) [Elm Extensions](http://it.toolbox.com/blogs/enlightenment/pyefl-tutorial-6-elmextensions-70278)
-- 7.) [Lists](http://it.toolbox.com/blogs/enlightenment/pyefl-tutorial-7-lists-70387)
-- 8.) [Genlist](http://it.toolbox.com/blogs/enlightenment/pyefl-tutorial-8-genlist-70590)
-- 9.) [Custom Widgets](http://it.toolbox.com/blogs/enlightenment/pyefl-tutorial-9-custom-elementary-widgets-71246)
+- 1.) [Hello Elementary](https://www.toolbox.com/tech/operating-systems/blogs/py-efl-tutorial-1-hello-elementary-022415/)
+- 2.) [Weight Hints](https://www.toolbox.com/tech/operating-systems/blogs/py-efl-tutorial-2-weight-hints-031215/)
+- 3.) [Align Hints](https://www.toolbox.com/tech/operating-systems/blogs/py-efl-tutorial-3-align-hints-041415/)
+- 4.) [Images / FileselectorButton](https://www.toolbox.com/tech/operating-systems/blogs/py-efl-tutorial-4-displaying-images-042415/)
+- 5.) [Naviframe](https://www.toolbox.com/tech/operating-systems/blogs/py-efl-tutorial-5-naviframe-070115/)
+- 6.) [Elm Extensions](https://www.toolbox.com/tech/operating-systems/blogs/py-efl-tutorial-6-elmextensions-110115/)
+- 7.) [Lists](https://www.toolbox.com/tech/operating-systems/blogs/pyefl-tutorial-7-lists-111115/)
+- 8.) [Genlist](https://www.toolbox.com/tech/programming/blogs/pyefl-tutorial-8-genlist-120215/)
+- 9.) [Custom Widgets](https://www.toolbox.com/tech/operating-systems/blogs/py-efl-tutorial-9-custom-elementary-widgets-020116/)
 - 10.) [Desktop Integration]
 - 11.) [Layout Widgets] 
 


### PR DESCRIPTION
Following comments on Bodhi Linux discord channel, some broken links relating to the tutorials (1-9) were identified. 